### PR TITLE
fix 0d entries

### DIFF
--- a/tpmc/include/tpmc/marchingcubes_impl.hh
+++ b/tpmc/include/tpmc/marchingcubes_impl.hh
@@ -36,15 +36,16 @@ namespace tpmc
 #ifdef ENABLE_TPMC_PROFILING
     ++profKeyGenerations_;
 #endif
+    const size_type vertex_count = std::distance(valuesBegin, valuesEnd);
     if ((dim < 0) || (dim > 3))
     {
       throw std::invalid_argument("Dimension must be 0, 1, 2 or 3");
     }
     else if (dim == 0)
     {
-      return 0;
+      assert(vertex_count == 1);
+      return *valuesBegin < 0 ? 0 : 1;
     }
-    const size_type vertex_count = std::distance(valuesBegin, valuesEnd);
     const unsigned int table_index = vertex_count + dim;
     const GeometryType geometry = makeGeometryType(dim, vertex_count);
 
@@ -176,8 +177,10 @@ namespace tpmc
     const unsigned int vertex_count = std::distance(valuesBegin, valuesEnd);
     const unsigned int table_index = vertex_count + dim;
 
-    const short* complex_vertex_index = Tables::all_complex_vertices[table_index]
-                  + Tables::all_case_offsets[table_index][key][INDEX_COMPLEX_VERTICES];
+    const short* complex_vertex_index =
+        Tables::all_complex_vertices[table_index];
+    complex_vertex_index +=
+        Tables::all_case_offsets[table_index][key][INDEX_COMPLEX_VERTICES];
 
     const unsigned int count = *complex_vertex_index++;
     for (unsigned int i = 0; i<count; ++i) {

--- a/tpmc/include/tpmc/marchinglut.hh
+++ b/tpmc/include/tpmc/marchinglut.hh
@@ -146,6 +146,7 @@ static const int INDEX_COMPLEX_VERTICES = 9;
 static const int INDEX_UNIQUE_CASE = 10;
 
 /* Mappings for vertex number to linear index in value array */
+static const short table_any0d_vertex_to_index[] = {0};
 static const short table_any1d_vertex_to_index[] = {0,1};
 static const short table_simplex2d_vertex_to_index[] = {0,1,2};
 static const short table_cube2d_vertex_to_index[] = {0,1,2,3};

--- a/tpmc/lut/lutgen/base_case_triangulation.py
+++ b/tpmc/lut/lutgen/base_case_triangulation.py
@@ -1951,10 +1951,10 @@ BCTany0d = LookupGenerator(0,"any")
 # base cases cube 0D:
 # 0 -> 0
 BCTany0d.base_cases[0].faces = []
-BCTany0d.base_cases[0].exterior = [[0]]
-BCTany0d.base_cases[0].exterior_groups = [0]
-BCTany0d.base_cases[0].interior = []
-BCTany0d.base_cases[0].interior_groups = []
+BCTany0d.base_cases[0].interior = [[0]]
+BCTany0d.base_cases[0].interior_groups = [0]
+BCTany0d.base_cases[0].exterior = []
+BCTany0d.base_cases[0].exterior_groups = []
 # generate code
 # BCTany0d.generate()
 

--- a/tpmc/src/marchingcubestables.cc
+++ b/tpmc/src/marchingcubestables.cc
@@ -8,7 +8,7 @@ namespace tpmc {
   /* table specialization for non symmetric tables */
 
   int MarchingCubesTables<SymmetryType::nonsymmetric>::all_max_complex_vertex_count[]
-      = { 0,                                    0,
+      = { 0,                                    table_any0d_max_complex_vertex_count,
           0,                                    table_any1d_max_complex_vertex_count,
           0,                                    table_simplex2d_max_complex_vertex_count,
           table_cube2d_max_complex_vertex_count,    table_simplex3d_max_complex_vertex_count,
@@ -21,7 +21,8 @@ namespace tpmc {
    */
   typename MarchingCubesTables<SymmetryType::nonsymmetric>::offsetRow *
   MarchingCubesTables<SymmetryType::nonsymmetric>::
-  all_case_offsets[] = {0, 0, 0, table_any1d_cases_offsets,
+  all_case_offsets[] = {0, table_any0d_cases_offsets, 0,
+                        table_any1d_cases_offsets,
                         0, table_simplex2d_cases_offsets,
                         table_cube2d_cases_offsets,
                         table_simplex3d_cases_offsets,
@@ -31,7 +32,8 @@ namespace tpmc {
 
   const short * const
   MarchingCubesTables<SymmetryType::nonsymmetric>::
-  all_case_vertices[] = {0, 0, 0, table_any1d_vertices,
+  all_case_vertices[] = {0, table_any0d_vertices, 0,
+                         table_any1d_vertices,
                          0, table_simplex2d_vertices,
                          table_cube2d_vertices, table_simplex3d_vertices,
                          table_pyramid3d_vertices, table_prism3d_vertices,
@@ -39,7 +41,8 @@ namespace tpmc {
 
   const short * const
   MarchingCubesTables<SymmetryType::nonsymmetric>::
-  all_vertex_to_index[] = {0, 0, 0, table_any1d_vertex_to_index,
+  all_vertex_to_index[] = {0, table_any0d_vertex_to_index, 0,
+                           table_any1d_vertex_to_index,
                            0, table_simplex2d_vertex_to_index,
                            table_cube2d_vertex_to_index,
                            table_simplex3d_vertex_to_index,
@@ -53,7 +56,8 @@ namespace tpmc {
    */
   const short * const
   MarchingCubesTables<SymmetryType::nonsymmetric>::
-  all_vertex_groups[] = {0, 0, 0, table_any1d_vertex_groups,
+  all_vertex_groups[] = {0, table_any0d_vertex_groups, 0,
+                         table_any1d_vertex_groups,
                          0, table_simplex2d_vertex_groups,
                          table_cube2d_vertex_groups,
                          table_simplex3d_vertex_groups,
@@ -67,7 +71,8 @@ namespace tpmc {
    */
   const short * const
   MarchingCubesTables<SymmetryType::nonsymmetric>::
-  all_codim_0[][2] = {{0, 0}, {0, 0}, {0, 0},
+  all_codim_0[][2] = {{0, 0}, {table_any0d_codim_0_interior,
+                       table_any0d_codim_0_exterior}, {0, 0},
                       {table_any1d_codim_0_interior,
                        table_any1d_codim_0_exterior}, {0, 0},
                       {table_simplex2d_codim_0_interior,
@@ -89,7 +94,8 @@ namespace tpmc {
    */
   const short * const
   MarchingCubesTables<SymmetryType::nonsymmetric>::
-  all_element_groups[][2] = {{0, 0}, {0, 0}, {0, 0},
+  all_element_groups[][2] = {{0, 0}, {table_any0d_interior_groups,
+                              table_any0d_exterior_groups}, {0, 0},
                              {table_any1d_interior_groups,
                               table_any1d_exterior_groups}, {0, 0},
                              {table_simplex2d_interior_groups,
@@ -111,7 +117,7 @@ namespace tpmc {
    */
   const short * const
   MarchingCubesTables<SymmetryType::nonsymmetric>::
-  all_codim_1[] = {0, 0, 0, table_any1d_codim_1,
+  all_codim_1[] = {0, table_any0d_codim_1, 0, table_any1d_codim_1,
                    0, table_simplex2d_codim_1,
                    table_cube2d_codim_1, table_simplex3d_codim_1,
                    table_pyramid3d_codim_1, table_prism3d_codim_1, 0,
@@ -143,7 +149,8 @@ namespace tpmc {
 
   const short * const
   MarchingCubesTables<SymmetryType::nonsymmetric>::
-  all_complex_vertices[] = {0, 0, 0, table_any1d_complex_vertices, 0, table_simplex2d_complex_vertices,
+  all_complex_vertices[] = {0, table_any0d_complex_vertices, 0, table_any1d_complex_vertices,
+                        0, table_simplex2d_complex_vertices,
                         table_cube2d_complex_vertices, table_simplex3d_complex_vertices,
                         table_pyramid3d_complex_vertices,
                         table_prism3d_complex_vertices, 0,
@@ -153,7 +160,7 @@ namespace tpmc {
   /** table secialization for symmetric cases */
 
   int MarchingCubesTables<SymmetryType::symmetric>::all_max_complex_vertex_count[]
-      = { 0,                                    0,
+      = { 0,                                    table_any0d_max_complex_vertex_count,
           0,                                    table_any1d_max_complex_vertex_count,
           0,                                    table_simplex2d_max_complex_vertex_count,
           table_cube2d_max_complex_vertex_count,    table_simplex3d_max_complex_vertex_count,
@@ -165,7 +172,8 @@ namespace tpmc {
    */
   typename MarchingCubesTables<SymmetryType::symmetric>::offsetRow *
   MarchingCubesTables<SymmetryType::symmetric>::
-  all_case_offsets[] = {0, 0, 0, table_any1d_cases_offsets,
+  all_case_offsets[] = {0, table_any0d_cases_offsets, 0,
+                        table_any1d_cases_offsets,
                         0, table_simplex2d_cases_offsets,
                         table_cube2d_cases_offsets,
                         table_simplex3d_cases_offsets,
@@ -175,7 +183,8 @@ namespace tpmc {
 
   const short * const
   MarchingCubesTables<SymmetryType::symmetric>::
-  all_case_vertices[] = {0, 0, 0, table_any1d_vertices,
+  all_case_vertices[] = {0, table_any0d_vertices, 0,
+                         table_any1d_vertices,
                          0, table_simplex2d_vertices,
                          table_cube2d_vertices, table_simplex3d_vertices,
                          table_pyramid3d_vertices, table_prism3d_vertices,
@@ -183,7 +192,8 @@ namespace tpmc {
 
   const short * const
   MarchingCubesTables<SymmetryType::symmetric>::
-  all_vertex_to_index[] = {0, 0, 0, table_any1d_vertex_to_index,
+  all_vertex_to_index[] = {0, table_any0d_vertex_to_index, 0,
+                           table_any1d_vertex_to_index,
                            0, table_simplex2d_vertex_to_index,
                            table_cube2d_vertex_to_index,
                            table_simplex3d_vertex_to_index,
@@ -197,7 +207,8 @@ namespace tpmc {
    */
   const short * const
   MarchingCubesTables<SymmetryType::symmetric>::
-  all_vertex_groups[] = {0, 0, 0, table_any1d_vertex_groups,
+  all_vertex_groups[] = {0, table_any0d_vertex_groups,
+                         0, table_any1d_vertex_groups,
                          0, table_simplex2d_vertex_groups,
                          table_cube2d_vertex_groups,
                          table_simplex3d_vertex_groups,
@@ -211,7 +222,8 @@ namespace tpmc {
    */
   const short * const
   MarchingCubesTables<SymmetryType::symmetric>::
-  all_codim_0[][2] = {{0, 0}, {0, 0}, {0, 0},
+  all_codim_0[][2] = {{0, 0}, {table_any0d_codim_0_interior,
+                       table_any0d_codim_0_exterior}, {0, 0},
                       {table_any1d_codim_0_interior,
                        table_any1d_codim_0_exterior}, {0, 0},
                       {table_simplex2d_codim_0_interior,
@@ -233,7 +245,8 @@ namespace tpmc {
    */
   const short * const
   MarchingCubesTables<SymmetryType::symmetric>::
-  all_element_groups[][2] = {{0, 0}, {0, 0}, {0, 0},
+  all_element_groups[][2] = {{0, 0}, {table_any0d_interior_groups,
+                              table_any0d_exterior_groups}, {0, 0},
                              {table_any1d_interior_groups,
                               table_any1d_exterior_groups}, {0, 0},
                              {table_simplex2d_interior_groups,
@@ -255,7 +268,7 @@ namespace tpmc {
    */
   const short * const
   MarchingCubesTables<SymmetryType::symmetric>::
-  all_codim_1[] = {0, 0, 0, table_any1d_codim_1,
+  all_codim_1[] = {0, table_any0d_codim_1, 0, table_any1d_codim_1,
                    0, table_simplex2d_codim_1,
                    table_cube2d_codim_1, table_simplex3d_codim_1,
                    table_pyramid3d_codim_1, table_prism3d_codim_1, 0,


### PR DESCRIPTION
This fixes several issues with a 0d marching cubes. The implementation is of course trivial but it was so far never used.

(use case: 1d cut-cell method, intersections between elements are 0d, i.e. points)